### PR TITLE
将弹窗抽象为组件并统一调用

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,0 +1,290 @@
+<!--
+    Modal.svelte - 通用弹窗组件
+    
+    可定制的弹窗组件，支持以下功能：
+    - 标题与内容自定义
+    - 可选的警告文本
+    - 确认和取消按钮
+    - 可自定义按钮文本
+    - 可选的表单提交功能
+    - 键盘Escape关闭
+    - 动画效果
+    
+    使用示例：
+    ```svelte
+    <script>
+        import Modal from '$lib/components/Modal.svelte';
+        
+        let showModal = false;
+        
+        function handleConfirm() {
+            // 处理确认逻辑
+            showModal = false;
+        }
+    </script>
+    
+    <button on:click={() => showModal = true}>显示弹窗</button>
+    
+    {#if showModal}
+        <Modal
+            title="确认操作"
+            content="您确定要执行此操作吗？"
+            warningText="此操作不可撤销。"
+            confirmText="确定"
+            cancelText="取消"
+            on:confirm={handleConfirm}
+            on:cancel={() => showModal = false}
+        />
+    {/if}
+    ```
+-->
+<script lang="ts">
+    import { createEventDispatcher } from 'svelte';
+    import { enhance } from '$app/forms';
+
+    // 弹窗属性
+    export let title: string = ''; // 弹窗标题
+    export let content: string = ''; // 弹窗内容
+    export let warningText: string = ''; // 警告文本（可选）
+    export let confirmText: string = '确定'; // 确认按钮文本
+    export let cancelText: string = '取消'; // 取消按钮文本
+    export let loading: boolean = false; // 加载状态
+    export let loadingText: string = '处理中...'; // 加载状态时的按钮文本
+    export let formAction: string = ''; // 表单提交的action（可选）
+    export let formData: Record<string, string> = {}; // 表单提交的数据（可选）
+    export let useEnhance: boolean = false; // 是否使用enhance增强表单（可选）
+    export let width: string = 'auto'; // 弹窗宽度，可以是auto或具体值
+    export let alignText: string = 'center'; // 文本对齐方式: 'left', 'center', 'right'
+    export let escapeToClose: boolean = true; // 是否允许使用Escape键关闭弹窗
+
+    // 事件派发器
+    const dispatch = createEventDispatcher();
+
+    // 处理确认事件
+    function handleConfirm() {
+        dispatch('confirm');
+    }
+
+    // 处理取消事件
+    function handleCancel() {
+        dispatch('cancel');
+    }
+
+    // 处理背景点击事件
+    function handleBackdropClick(event: MouseEvent) {
+        // 只有当点击的是背景层时才关闭弹窗
+        if (event.target === event.currentTarget) {
+            dispatch('cancel');
+        }
+    }
+
+    // 处理键盘事件
+    function handleKeydown(event: KeyboardEvent) {
+        if (escapeToClose && event.key === 'Escape') {
+            dispatch('cancel');
+        }
+    }
+
+    // 当表单使用enhance增强时的处理函数
+    function enhanceForm() {
+        dispatch('beforeSubmit');
+        return async ({ update }: { update: () => Promise<void> }) => {
+            await update();
+            dispatch('afterSubmit');
+        };
+    }
+</script>
+
+<div 
+    class="modal-mask" 
+    on:click={handleBackdropClick}
+    on:keydown={handleKeydown}
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+>
+    <div 
+        class="modal-dialog"
+        role="document"
+        style="width: {width}; text-align: {alignText};"
+    >
+        {#if title}
+            <div class="modal-title">{title}</div>
+        {/if}
+        
+        <div class="modal-content">
+            {#if content}
+                {@html content.replace(/\n/g, '<br>')}
+            {/if}
+            <slot name="content"></slot>
+            
+            {#if warningText}
+                <span class="warning-text">{warningText}</span>
+            {/if}
+        </div>
+        
+        <div class="modal-actions">
+            {#if formAction}
+                <form 
+                    method="post" 
+                    action={formAction}
+                    use:enhance={useEnhance ? enhanceForm : undefined}
+                >
+                    {#each Object.entries(formData) as [name, value]}
+                        <input type="hidden" {name} {value} />
+                    {/each}
+                    
+                    <slot name="form-fields"></slot>
+                    
+                    <button 
+                        class="btn-primary" 
+                        type="submit"
+                        disabled={loading}
+                    >
+                        {loading ? loadingText : confirmText}
+                    </button>
+                    
+                    <button type="button" class="btn-secondary" on:click={handleCancel}>
+                        {cancelText}
+                    </button>
+                </form>
+            {:else}
+                <button 
+                    class="btn-primary" 
+                    type="button"
+                    on:click={handleConfirm}
+                    disabled={loading}
+                >
+                    {loading ? loadingText : confirmText}
+                </button>
+                
+                <button type="button" class="btn-secondary" on:click={handleCancel}>
+                    {cancelText}
+                </button>
+            {/if}
+            
+            <slot name="actions"></slot>
+        </div>
+        
+        <slot></slot>
+    </div>
+</div>
+
+<style>
+    /* 弹窗样式 */
+    .modal-mask {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        background: rgba(0, 0, 0, 0.25);
+        z-index: 2000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .modal-dialog {
+        background: #fff;
+        border-radius: 10px;
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+        padding: 2rem 2.5rem 1.5rem 2.5rem;
+        min-width: 280px;
+        max-width: 90vw;
+        animation: modalIn 0.18s cubic-bezier(0.4, 1.6, 0.6, 1) both;
+    }
+
+    @keyframes modalIn {
+        from { 
+            transform: scale(0.95) translateY(30px); 
+            opacity: 0; 
+        }
+        to { 
+            transform: scale(1) translateY(0); 
+            opacity: 1; 
+        }
+    }
+
+    .modal-title {
+        font-size: 1.25rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        color: #212121;
+    }
+
+    .modal-content {
+        color: #757575;
+        margin-bottom: 1.5rem;
+        line-height: 1.5;
+    }
+
+    .warning-text {
+        color: #f44336;
+        font-weight: 500;
+        display: block;
+        margin-top: 0.5rem;
+    }
+
+    .modal-actions {
+        display: flex;
+        gap: 1rem;
+        justify-content: center;
+    }
+
+    .btn-primary {
+        background-color: #212121;
+        color: #fff;
+        border: none;
+        padding: 0.6rem 1.5rem;
+        border-radius: 8px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background-color 0.2s ease;
+    }
+
+    .btn-primary:hover:not(:disabled) {
+        background-color: #000;
+    }
+
+    .btn-primary:disabled {
+        background-color: #9e9e9e;
+        cursor: not-allowed;
+    }
+
+    .btn-secondary {
+        background-color: #f5f5f5;
+        color: #757575;
+        border: 1px solid #e0e0e0;
+        padding: 0.6rem 1.5rem;
+        border-radius: 8px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .btn-secondary:hover {
+        background-color: #e0e0e0;
+        color: #212121;
+        border-color: #212121;
+    }
+
+    /* 响应式设计 */
+    @media (max-width: 640px) {
+        .modal-dialog {
+            padding: 1.5rem;
+            width: calc(100% - 2rem) !important;
+            max-width: none;
+            margin: 0 1rem;
+        }
+
+        .modal-actions {
+            flex-direction: column;
+        }
+
+        .btn-primary, .btn-secondary {
+            width: 100%;
+            margin-bottom: 0.5rem;
+        }
+    }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
     import { goto } from "$app/navigation";
+    import Modal from '$lib/components/Modal.svelte';
 
     let { data, children } = $props();
 
@@ -48,94 +49,21 @@
 
 <!-- 
   设计理念: 
-  - 使用 <header> 作为承载导航的“材质卡片”。
-  - position: sticky 和 backdrop-filter 创造出悬浮的“磨砂玻璃”效果，这是现代UI中常见的科技感元素。
+  - 使用 <header> 作为承载导航的"材质卡片"。
+  - position: sticky 和 backdrop-filter 创造出悬浮的"磨砂玻璃"效果，这是现代UI中常见的科技感元素。
   - 它在滚动时会覆盖在内容之上，提供了清晰的视觉层级。
 -->
 <header class="main-header">
     {#if showLogoutDialog}
-        <div class="modal-mask">
-            <div class="modal-dialog">
-                <div class="modal-title">确认登出</div>
-                <div class="modal-content">确定要登出当前账号吗？</div>
-                <div class="modal-actions">
-                    <button class="btn-primary" onclick={confirmLogout}>确定</button>
-                    <button class="btn-secondary" onclick={cancelLogout}>取消</button>
-                </div>
-            </div>
-        </div>
+        <Modal
+            title="确认登出"
+            content="确定要登出当前账号吗？"
+            confirmText="确定"
+            cancelText="取消"
+            on:confirm={confirmLogout}
+            on:cancel={cancelLogout}
+        />
     {/if}
-<style>
-    .modal-mask {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        background: rgba(0,0,0,0.25);
-        z-index: 2000;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    .modal-dialog {
-        background: #fff;
-        border-radius: 10px;
-        box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-        padding: 2rem 2.5rem 1.5rem 2.5rem;
-        min-width: 280px;
-        max-width: 90vw;
-        text-align: center;
-        animation: modalIn 0.18s cubic-bezier(.4,1.6,.6,1) both;
-    }
-    @keyframes modalIn {
-        from { transform: scale(0.95) translateY(30px); opacity: 0; }
-        to { transform: scale(1) translateY(0); opacity: 1; }
-    }
-    .modal-title {
-        font-size: 1.25rem;
-        font-weight: 700;
-        margin-bottom: 0.5rem;
-        color: var(--text-primary);
-    }
-    .modal-content {
-        color: var(--text-secondary);
-        margin-bottom: 1.5rem;
-    }
-    .modal-actions {
-        display: flex;
-        gap: 1rem;
-        justify-content: center;
-    }
-    .btn-primary {
-        background-color: var(--text-primary);
-        color: var(--surface-bg);
-        border: none;
-        padding: 0.6rem 1.5rem;
-        border-radius: var(--border-radius-md);
-        font-weight: 600;
-        cursor: pointer;
-        transition: background-color var(--transition-speed) ease;
-    }
-    .btn-primary:hover {
-        background-color: #000;
-    }
-    .btn-secondary {
-        background-color: var(--background);
-        color: var(--text-secondary);
-        border: 1px solid var(--border-color);
-        padding: 0.6rem 1.5rem;
-        border-radius: var(--border-radius-md);
-        font-weight: 600;
-        cursor: pointer;
-        transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease, border-color var(--transition-speed) ease;
-    }
-    .btn-secondary:hover {
-        background-color: var(--hover-bg);
-        color: var(--text-primary);
-        border-color: var(--text-primary);
-    }
-</style>
     <nav class="navbar">
         <div class="logo">
             <a href="/">Synapse</a>
@@ -171,7 +99,7 @@
         <!-- 
           设计理念:
           - 链接具有更大的点击区域和更柔和的背景反馈，而非简单的文字变色。
-          - 这种“药丸”或“芯片”形状的背景反馈是Material Design的常见实践。
+          - 这种"药丸"或"芯片"形状的背景反馈是Material Design的常见实践。
           - 对用户相关的操作（面板、登入登出）也使用图标，保持视觉统一性。
         -->
         <ul class="nav-links">

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -5,6 +5,7 @@
     import { page } from '$app/stores';
     import type { ActionData, PageData } from './$types';
     import type { AdminClient, UserClient } from '$lib/types/client';
+    import Modal from '$lib/components/Modal.svelte';
 
     let { data, form } = $props<{ 
         data: PageData & { 
@@ -486,52 +487,23 @@
 
         <!-- 删除确认弹窗 -->
         {#if deleteConfirmId}
-            <div 
-                class="modal-mask" 
-                onclick={cancelDelete}
-                onkeydown={(e) => e.key === 'Escape' && cancelDelete()}
-                role="dialog"
-                aria-modal="true"
-                tabindex="-1"
-            >
-                <div 
-                    class="modal-dialog"
-                    role="document"
-                >
-                    <div class="modal-title">确认删除用户</div>
-                    <div class="modal-content">
-                        您确定要删除这个用户吗？此操作不可撤销。<br>
-                        <span class="warning-text">删除用户将同时删除其所有相关数据，包括文章和评论。</span>
-                    </div>
-                    <div class="modal-actions">
-                        <form 
-                            method="post" 
-                            action="?/deleteUser"
-                            use:enhance={() => {
-                                isDeleting = true;
-                                return async ({ update }) => {
-                                    isDeleting = false;
-                                    deleteConfirmId = null;
-                                    await update();
-                                    await invalidateAll();
-                                };
-                            }}
-                        >
-                            <input type="hidden" name="userId" value={deleteConfirmId} />
-                            <button 
-                                class="btn-primary" 
-                                type="submit"
-                                disabled={isDeleting}
-                            >
-                                {isDeleting ? '删除中...' : '确定'}
-                            </button>
-                        </form>
-                        <button type="button" class="btn-secondary" onclick={cancelDelete}>
-                            取消
-                        </button>
-                    </div>
-                </div>
-            </div>
+            <Modal
+                title="确认删除用户"
+                content="您确定要删除这个用户吗？此操作不可撤销。<br><span class='warning-text'>删除用户将同时删除其所有相关数据，包括文章和评论。</span>"
+                confirmText={isDeleting ? '删除中...' : '确定'}
+                cancelText="取消"
+                loading={isDeleting}
+                formAction="?/deleteUser"
+                formData={{ userId: deleteConfirmId }}
+                useEnhance={true}
+                on:beforeSubmit={() => { isDeleting = true; }}
+                on:afterSubmit={async () => {
+                    isDeleting = false;
+                    deleteConfirmId = null;
+                    await invalidateAll();
+                }}
+                on:cancel={cancelDelete}
+            />
         {/if}
     </div>
 </main>
@@ -1076,103 +1048,12 @@
         line-height: 1.4;
     }
 
-    /* 弹窗样式 - 与网站主题保持一致 */
-    .modal-mask {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        background: rgba(0, 0, 0, 0.25);
-        z-index: 2000;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-    .modal-dialog {
-        background: #fff;
-        border-radius: 10px;
-        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
-        padding: 2rem 2.5rem 1.5rem 2.5rem;
-        min-width: 280px;
-        max-width: 90vw;
-        text-align: center;
-        animation: modalIn 0.18s cubic-bezier(0.4, 1.6, 0.6, 1) both;
-    }
-
-    @keyframes modalIn {
-        from { 
-            transform: scale(0.95) translateY(30px); 
-            opacity: 0; 
-        }
-        to { 
-            transform: scale(1) translateY(0); 
-            opacity: 1; 
-        }
-    }
-
-    .modal-title {
-        font-size: 1.25rem;
-        font-weight: 700;
-        margin-bottom: 0.5rem;
-        color: #212121; /* 直接使用主题色值 */
-    }
-
-    .modal-content {
-        color: #757575; /* 直接使用主题色值 */
-        margin-bottom: 1.5rem;
-        line-height: 1.5;
-    }
-
+    /* 警告文本样式 - 与其他页面保持一致 */
     .warning-text {
         color: #f44336;
         font-weight: 500;
         display: block;
         margin-top: 0.5rem;
-    }
-
-    .modal-actions {
-        display: flex;
-        gap: 1rem;
-        justify-content: center;
-    }
-
-    .btn-primary {
-        background-color: #212121;
-        color: #fff;
-        border: none;
-        padding: 0.6rem 1.5rem;
-        border-radius: 8px;
-        font-weight: 600;
-        cursor: pointer;
-        transition: background-color 0.2s ease;
-    }
-
-    .btn-primary:hover:not(:disabled) {
-        background-color: #000;
-    }
-
-    .btn-primary:disabled {
-        background-color: #9e9e9e;
-        cursor: not-allowed;
-    }
-
-    .btn-secondary {
-        background-color: #f5f5f5;
-        color: #757575;
-        border: 1px solid #e0e0e0;
-        padding: 0.6rem 1.5rem;
-        border-radius: 8px;
-        font-weight: 600;
-        cursor: pointer;
-        transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-    }
-
-    .btn-secondary:hover {
-        background-color: #e0e0e0;
-        color: #212121;
-        border-color: #212121;
     }
 
     /* 响应式设计 */
@@ -1203,15 +1084,6 @@
         .filter-button {
             flex: 1;
             min-width: 80px;
-        }
-
-        .modal-footer {
-            flex-direction: column;
-        }
-
-        .modal-content {
-            width: 95%;
-            margin: 16px;
         }
 
         .section-header {

--- a/src/routes/my/articles/+page.svelte
+++ b/src/routes/my/articles/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
     import ArticleCard from "$lib/components/ArticleCard.svelte";
+    import Modal from "$lib/components/Modal.svelte";
     // 假设后端会通过 load 函数传递 articles
     export let data: { articles: any[] };
 
@@ -74,21 +75,16 @@ async function confirmDeleteArticle() {
 {/if}
 
 {#if showDeleteModal}
-    <div class="modal-backdrop" tabindex="-1">
-        <div class="logout-modal" role="dialog" aria-modal="true">
-            <div class="modal-title">确认删除</div>
-            <div class="modal-content">确定要删除这篇文章吗？此操作不可撤销。</div>
-            {#if deleteError}
-                <div class="modal-error">{deleteError}</div>
-            {/if}
-            <div class="modal-actions">
-                <button class="modal-cancel" on:click={closeDeleteModal} disabled={deleteLoading}>取消</button>
-                <button class="modal-confirm" on:click={confirmDeleteArticle} disabled={deleteLoading}>
-                    {deleteLoading ? '正在删除...' : '确认删除'}
-                </button>
-            </div>
-        </div>
-    </div>
+    <Modal
+        title="确认删除"
+        content="确定要删除这篇文章吗？此操作不可撤销。"
+        warningText={deleteError || ''}
+        confirmText={deleteLoading ? '正在删除...' : '确认删除'}
+        cancelText="取消"
+        loading={deleteLoading}
+        on:confirm={confirmDeleteArticle}
+        on:cancel={closeDeleteModal}
+    />
 {/if}
 
 <style>
@@ -164,79 +160,4 @@ async function confirmDeleteArticle() {
         background: #ffffff;
         color: #000000;
     }
-/* 自定义弹窗样式（与 layout 保持一致） */
-.modal-backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background: rgba(0,0,0,0.25);
-    z-index: 2000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.logout-modal {
-    background: #fff;
-    border-radius: 12px;
-    box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    padding: 2rem 2.5rem 1.5rem 2.5rem;
-    min-width: 280px;
-    max-width: 90vw;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    animation: modal-pop 0.18s cubic-bezier(.4,1.4,.6,1) both;
-}
-.modal-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-}
-.modal-content {
-    color: #555;
-    margin-bottom: 1.2rem;
-}
-.modal-error {
-    color: #d32f2f;
-    margin-bottom: 0.8rem;
-    font-size: 0.98rem;
-}
-.modal-actions {
-    display: flex;
-    gap: 1.2rem;
-}
-.modal-cancel, .modal-confirm {
-    min-width: 80px;
-    padding: 0.5rem 1.2rem;
-    border-radius: 6px;
-    border: none;
-    font-size: 1rem;
-    font-family: inherit;
-    cursor: pointer;
-    transition: background 0.18s, color 0.18s;
-}
-.modal-cancel {
-    background: #f5f5f5;
-    color: #555;
-}
-.modal-cancel:hover:enabled {
-    background: #e0e0e0;
-}
-.modal-confirm {
-    background: var(--text-primary);
-    color: #fff;
-}
-.modal-confirm:hover:enabled {
-    background: #424242;
-}
-.modal-confirm:disabled, .modal-cancel:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-@keyframes modal-pop {
-    0% { transform: scale(0.92); opacity: 0; }
-    100% { transform: scale(1); opacity: 1; }
-}
 </style>

--- a/src/routes/my/drafts/+page.svelte
+++ b/src/routes/my/drafts/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
+    import Modal from '$lib/components/Modal.svelte';
     
     let { data } = $props();
     let drafts = $state([...data.drafts]);
@@ -64,13 +65,6 @@
 
     function handleCancel() {
         showConfirmDialog = false;
-    }
-
-    // 处理对话框背景点击
-    function handleOverlayClick(event: MouseEvent) {
-        if (event.target === event.currentTarget) {
-            handleCancel();
-        }
     }
 
     function toNewArticle() {
@@ -199,35 +193,14 @@
 
 <!-- 确认对话框 -->
 {#if showConfirmDialog}
-    <div 
-        class="dialog-overlay" 
-        onclick={handleOverlayClick}
-        onkeydown={(e) => e.key === 'Escape' && handleCancel()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="dialog-title"
-        tabindex="-1"
-    >
-        <div 
-            class="dialog-container" 
-            role="document"
-        >
-            <div class="dialog-header">
-                <h3 id="dialog-title" class="dialog-title">{confirmTitle}</h3>
-            </div>
-            <div class="dialog-content">
-                <p>{confirmMessage}</p>
-            </div>
-            <div class="dialog-actions">
-                <button type="button" onclick={handleCancel} class="dialog-btn dialog-cancel-btn">
-                    取消
-                </button>
-                <button type="button" onclick={handleConfirm} class="dialog-btn dialog-confirm-btn">
-                    确认
-                </button>
-            </div>
-        </div>
-    </div>
+    <Modal
+        title={confirmTitle}
+        content={confirmMessage}
+        confirmText="确认"
+        cancelText="取消"
+        on:confirm={handleConfirm}
+        on:cancel={handleCancel}
+    />
 {/if}
 
 <style>
@@ -634,148 +607,6 @@
 
         .new-article-btn {
             padding: 0.875rem 1.5rem;
-            font-size: 1rem;
-        }
-    }
-
-    /* 
-      设计理念: 确认对话框 - 与主站设计完全一致
-      - 采用黑白灰配色系统
-      - 使用与主站相同的阴影、圆角、过渡效果
-      - 按钮风格与主站按钮保持一致
-    */
-    .dialog-overlay {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: rgba(0, 0, 0, 0.5);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        z-index: 1000;
-        animation: fadeIn 0.15s ease-out;
-    }
-
-    @keyframes fadeIn {
-        from {
-            opacity: 0;
-        }
-        to {
-            opacity: 1;
-        }
-    }
-
-    .dialog-container {
-        background-color: #ffffff;
-        border-radius: var(--border-radius-md);
-        box-shadow:
-            0 4px 12px rgba(0, 0, 0, 0.15),
-            0 8px 24px rgba(0, 0, 0, 0.1);
-        max-width: 400px;
-        width: 90%;
-        animation: slideIn 0.2s ease-out;
-    }
-
-    @keyframes slideIn {
-        from {
-            opacity: 0;
-            transform: translateY(-20px) scale(0.95);
-        }
-        to {
-            opacity: 1;
-            transform: translateY(0) scale(1);
-        }
-    }
-
-    .dialog-header {
-        padding: 1.5rem 1.5rem 0 1.5rem;
-        border-bottom: 1px solid var(--border-color);
-        padding-bottom: 1rem;
-        margin-bottom: 1rem;
-    }
-
-    .dialog-title {
-        margin: 0;
-        font-size: 1.25rem;
-        font-weight: 600;
-        color: var(--text-primary);
-    }
-
-    .dialog-content {
-        padding: 0 1.5rem 1.5rem 1.5rem;
-    }
-
-    .dialog-content p {
-        margin: 0;
-        color: var(--text-secondary);
-        line-height: 1.6;
-        font-size: 1rem;
-    }
-
-    .dialog-actions {
-        display: flex;
-        gap: 0.75rem;
-        justify-content: flex-end;
-        padding: 0 1.5rem 1.5rem 1.5rem;
-    }
-
-    .dialog-btn {
-        padding: 0.75rem 1.5rem;
-        border-radius: var(--border-radius-md);
-        font-size: 0.9rem;
-        font-weight: 500;
-        cursor: pointer;
-        transition:
-            background-color var(--transition-speed) ease,
-            border-color var(--transition-speed) ease,
-            color var(--transition-speed) ease;
-    }
-
-    .dialog-cancel-btn {
-        background-color: #ffffff;
-        color: var(--text-secondary);
-        border: 1px solid var(--border-color);
-    }
-
-    .dialog-cancel-btn:hover {
-        background-color: var(--background);
-        border-color: var(--text-secondary);
-        color: var(--text-primary);
-    }
-
-    .dialog-confirm-btn {
-        background-color: var(--text-primary);
-        color: #ffffff;
-        border: 1px solid var(--text-primary);
-    }
-
-    .dialog-confirm-btn:hover {
-        background-color: #424242;
-        border-color: #424242;
-    }
-
-    /* 对话框响应式设计 */
-    @media (max-width: 480px) {
-        .dialog-container {
-            width: 95%;
-            max-width: none;
-        }
-
-        .dialog-header,
-        .dialog-content,
-        .dialog-actions {
-            padding-left: 1rem;
-            padding-right: 1rem;
-        }
-
-        .dialog-actions {
-            flex-direction: column;
-        }
-
-        .dialog-btn {
-            padding: 0.875rem 1.25rem;
             font-size: 1rem;
         }
     }

--- a/src/routes/password/reset/+page.svelte
+++ b/src/routes/password/reset/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { goto } from '$app/navigation';
+import Modal from '$lib/components/Modal.svelte';
 
 let email = '';
 let code = '';
@@ -196,15 +197,14 @@ function gotoLogin() {
 </main>
 
 {#if showSuccessModal}
-    <div class="modal-backdrop" tabindex="-1">
-        <div class="logout-modal" role="dialog" aria-modal="true">
-            <div class="modal-title">密码重置成功</div>
-            <div class="modal-content">密码重置成功，请用新密码登录。</div>
-            <div class="modal-actions">
-                <button class="modal-confirm" on:click={gotoLogin}>去登录</button>
-            </div>
-        </div>
-    </div>
+    <Modal
+        title="密码重置成功"
+        content="密码重置成功，请用新密码登录。"
+        confirmText="去登录"
+        cancelText="留在此页"
+        on:confirm={gotoLogin}
+        on:cancel={() => showSuccessModal = false}
+    />
 {/if}
 
 <style>
@@ -454,77 +454,5 @@ function gotoLogin() {
         .form-group {
             margin-bottom: 1.25rem;
         }
-    }
-
-    /* 自定义弹窗样式（与 layout 保持一致） */
-    .modal-backdrop {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        background: rgba(0,0,0,0.25);
-        z-index: 2000;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    .logout-modal {
-        background: #fff;
-        border-radius: 12px;
-        box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-        padding: 2rem 2.5rem 1.5rem 2.5rem;
-        min-width: 280px;
-        max-width: 90vw;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        animation: modal-pop 0.18s cubic-bezier(.4,1.4,.6,1) both;
-    }
-    .modal-title {
-        font-size: 1.25rem;
-        font-weight: 600;
-        margin-bottom: 0.5rem;
-    }
-    .modal-content {
-        color: #555;
-        margin-bottom: 1.2rem;
-    }
-    .modal-actions {
-        display: flex;
-        gap: 1.2rem;
-        margin-top: 0.5rem;
-    }
-    .modal-cancel, .modal-confirm {
-        min-width: 80px;
-        padding: 0.5rem 1.2rem;
-        border-radius: 6px;
-        border: none;
-        font-size: 1rem;
-        font-family: inherit;
-        cursor: pointer;
-        transition: background 0.18s, color 0.18s;
-    }
-    .modal-cancel {
-        background: #f5f5f5;
-        color: #555;
-    }
-    .modal-cancel:hover:enabled {
-        background: #e0e0e0;
-    }
-    .modal-confirm {
-        background: var(--text-primary);
-        color: #fff;
-    }
-    .modal-confirm:hover:enabled {
-        background: #424242;
-    }
-    .modal-confirm:disabled, .modal-cancel:disabled {
-        opacity: 0.6;
-        cursor: not-allowed;
-    }
-    @keyframes modal-pop {
-        0% { transform: scale(0.92); opacity: 0; }
-        100% { transform: scale(1); opacity: 1; }
     }
 </style>


### PR DESCRIPTION
将弹窗抽象为组件Modal，并用其替代项目中所有需要运用弹窗的页面，实现统一调用、模块服用，包括：①主布局中的登出确认弹窗；②草稿管理页面的确认弹窗；③文章管理页面的删除确认弹窗；④管理员用户页面的删除确认弹窗；⑤管理员文章页面的弹窗；⑥管理员评论页面的删除确认弹窗；⑦管理员编辑页面的弹窗；⑧密码重置页面的确认弹窗。